### PR TITLE
I have fixed the SSL mixed content warning problem.

### DIFF
--- a/nf-gravatar-cache.php
+++ b/nf-gravatar-cache.php
@@ -203,6 +203,8 @@ class NFGC_Gravatar_Cache {
             update_option( 'nf_avatars_cache', $nf_avatars_cache );
         }
 
+        $g_url = str_replace("http://", "//", $g_url);
+
         return '<img alt="" src=\''.$g_url.'\' class="avatar avatar-'.$size.'" width="'.$size.'" height="'.$size.'" />';
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -30,3 +30,7 @@ Caches Gravatars to your host and speed up your site.
 = 0.0.6 =
 
 Some bugs were fixed
+
+= 0.0.6.1 =
+
+Fix SSL environment compatibility.


### PR DESCRIPTION
The latest version of this plugin doesn't work well in the https environment. Because it use http link instead of https. Then the modern browser like Chrom will give several warning. My solution is to replace the link string with "//", which is compatible both in http and https.
